### PR TITLE
fix: nested MatchRules without "match" doesn't work

### DIFF
--- a/plugin/rules/match.py
+++ b/plugin/rules/match.py
@@ -81,7 +81,7 @@ class MatchRule(Optimizable):
             rule_class: Optional[Type[MatchableRule]] = None
             if "constraint" in rule:
                 rule_class = ConstraintRule
-            elif "match" in rule:
+            elif "rules" in rule:  # nested MatchRule
                 rule_class = MatchRule
             if rule_class and (rule_compiled := rule_class.make(rule)):  # type: ignore
                 rules_compiled.append(rule_compiled)


### PR DESCRIPTION
Fixes https://github.com/jfcherng-sublime/ST-AutoSetSyntax/issues/10